### PR TITLE
Handle UTF-8 encoding for header titles and sheet names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>pl.nowekolory</groupId>
     <artifactId>objectifyxlsx</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>pl.nowekolory</groupId>
     <artifactId>objectifyxlsx</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/src/main/java/pl/nowekolory/objectifyxlsx/ExcelWriter.java
+++ b/src/main/java/pl/nowekolory/objectifyxlsx/ExcelWriter.java
@@ -8,6 +8,7 @@ import pl.nowekolory.objectifyxlsx.header.HeaderCreator;
 import pl.nowekolory.objectifyxlsx.row.RowCreator;
 
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class ExcelWriter {
@@ -98,7 +99,7 @@ public class ExcelWriter {
         if (name == null || name.isBlank()) {
             return clazz.getName();
         }
-        return name;
+        return new String(name.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
     }
 
     private void createRows(Sheet sheet, List<?> objectsToWrite) {

--- a/src/main/java/pl/nowekolory/objectifyxlsx/header/HeaderCreator.java
+++ b/src/main/java/pl/nowekolory/objectifyxlsx/header/HeaderCreator.java
@@ -25,6 +25,9 @@ public class HeaderCreator{
         var cellIndex = 0;
         var headerCellStyle = CellStyleCreator.createHeaderCellStyle(workbook);
         for(var title : headersValues){
+            if (title == null) {
+                title = "";
+            }
             var utf8Title = new String(title.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
             cellCreator.addCell(row, utf8Title, cellIndex);
             cellIndex++;

--- a/src/main/java/pl/nowekolory/objectifyxlsx/header/HeaderCreator.java
+++ b/src/main/java/pl/nowekolory/objectifyxlsx/header/HeaderCreator.java
@@ -6,6 +6,7 @@ import pl.nowekolory.objectifyxlsx.cell.CellCreator;
 import pl.nowekolory.objectifyxlsx.cell.CellStyleCreator;
 
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +25,8 @@ public class HeaderCreator{
         var cellIndex = 0;
         var headerCellStyle = CellStyleCreator.createHeaderCellStyle(workbook);
         for(var title : headersValues){
-            cellCreator.addCell(row, title, cellIndex);
+            var utf8Title = new String(title.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+            cellCreator.addCell(row, utf8Title, cellIndex);
             cellIndex++;
         }
         for(var i = 0; i < headersValues.size(); i++){

--- a/src/test/java/pl/nowekolory/objectifyxlsx/ExcelWriterTest.java
+++ b/src/test/java/pl/nowekolory/objectifyxlsx/ExcelWriterTest.java
@@ -1,0 +1,61 @@
+package pl.nowekolory.objectifyxlsx;
+
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExcelWriterTest {
+
+    @Test
+    void testCreateSheetWithPolishCharactersInName() throws Exception {
+        try (var workbook = WorkbookFactory.create(false)) {
+            var excelWriter = new ExcelWriter(workbook);
+            var polishSheetName = "Arkusz Żółty";
+
+            var objectsToWrite = Arrays.asList(
+                    new TestObject("Element 1"),
+                    new TestObject("Element 2")
+            );
+
+            excelWriter.createSheet(objectsToWrite, polishSheetName);
+
+            assertEquals(polishSheetName, workbook.getSheetAt(0).getSheetName(),
+                    "Nazwa arkusza powinna zostać poprawnie zakodowana");
+        }
+    }
+
+    @Test
+    void testCreateSheetWithDefaultClassNameWhenNameIsNull() throws Exception {
+        try (var workbook = WorkbookFactory.create(false)) {
+            ExcelWriter excelWriter = new ExcelWriter(workbook);
+
+            var objectsToWrite = List.of(
+                    new TestObject("Element 1")
+            );
+
+            excelWriter.createSheet(objectsToWrite, null);
+
+            var expectedSheetName = TestObject.class.getName().substring(0, 31); // nazwy arkuszy excel mają limitację 31 znaków
+            assertEquals(expectedSheetName, workbook.getSheetAt(0).getSheetName(),
+                    "Nazwą arkusza powinna być skrócona nazwa klasy obiektu do 31 znaków");
+        }
+    }
+
+
+    static class TestObject {
+        private final String value;
+
+        TestObject(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/src/test/java/pl/nowekolory/objectifyxlsx/header/HeaderCreatorTest.java
+++ b/src/test/java/pl/nowekolory/objectifyxlsx/header/HeaderCreatorTest.java
@@ -1,0 +1,48 @@
+package pl.nowekolory.objectifyxlsx.header;
+
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeaderCreatorTest {
+
+    @Test
+    void testCreateHeaderWithPolishCharacters() throws Exception {
+        try (var workbook = WorkbookFactory.create(false)) {
+            var sheet = workbook.createSheet("TestSheet");
+
+            var headersWithPolishCharacters = Arrays.asList("Nagłówek 1", "Kolumna Łącząca", "Wartość Żródłowa");
+
+            HeaderCreator.createHeader(sheet, workbook, headersWithPolishCharacters);
+
+            for (var i = 0; i < headersWithPolishCharacters.size(); i++) {
+                var expectedHeader = headersWithPolishCharacters.get(i);
+                var actualHeader = sheet.getRow(0).getCell(i).getStringCellValue();
+                assertEquals(expectedHeader, actualHeader,
+                        "Sprawdzenie, czy nagłówek został poprawnie zakodowany dla indeksu: " + i);
+            }
+        }
+    }
+
+    @Test
+    void shouldHandleNullTitleInHeadersList() throws Exception {
+        try (var workbook = WorkbookFactory.create(false)) {
+            var sheet = workbook.createSheet();
+            List<String> headersValues = new ArrayList<>();
+            headersValues.add("Column1");
+            headersValues.add(null);
+            headersValues.add("Column3");
+
+            assertDoesNotThrow(() ->
+                            HeaderCreator.createHeader(sheet, workbook, headersValues),
+                    "Metoda powinna obsłużyć przypadek, gdy jeden z nagłówków jest null");
+        }
+    }
+
+
+}


### PR DESCRIPTION
Ensure header titles and sheet names are properly encoded in UTF-8 to handle special characters. Updated version in pom.xml to 1.1.6-SNAPSHOT to reflect the changes.